### PR TITLE
Add missing conditional around closing brackets

### DIFF
--- a/lib/Mac/edk.framework/Versions/A/Headers/IEmotivProfile.h
+++ b/lib/Mac/edk.framework/Versions/A/Headers/IEmotivProfile.h
@@ -168,6 +168,8 @@ extern "C" {
         IEE_SaveUserProfile(unsigned int userID,
                             const char * szOutputFilename);
 
+#ifdef __cplusplus
 };
+#endif
 
 #endif // IEMOTIVPROFILE_H


### PR DESCRIPTION
The header file was missing a conditional around the closing brackets, while the corresponding opening brackets are only included in `__cplusplus`, preventing the header from being imported in C