### PR TITLE
Make the header files valid C (and C++)

### DIFF
--- a/include/IEmotivProfile.h
+++ b/include/IEmotivProfile.h
@@ -168,6 +168,8 @@ extern "C" {
         IEE_SaveUserProfile(unsigned int userID,
                             const char * szOutputFilename);
 
-};
+#ifdef __cplusplus
+}
+#endif
 
 #endif // IEMOTIVPROFILE_H

--- a/include/Iedk.h
+++ b/include/Iedk.h
@@ -190,8 +190,13 @@ extern "C" {
 
         \sa IedkErrorCode.h
     */
+#ifdef __cplusplus
     EDK_API int
         IEE_EngineConnect(const char* strDevID = "Emotiv Systems-5");
+#else
+    EDK_API int
+        IEE_EngineConnect(const char* strDevID);
+#endif
 
     
     //! Initialize the connection to a remote instance of EmoEngine.


### PR DESCRIPTION
I tried to create bindings using the provided header files and found two issues making them invalid C files:
```
/usr/local/include/IEmotivProfile.h:171:1: error: extraneous closing brace ('}'), err: true
/usr/local/include/Iedk.h:194:48: error: C does not support default arguments, err: true
```
These changes should fix that while keeping the code as valid C++ and keeping the default argument when compiling as C++ code.